### PR TITLE
Standard cluster updates

### DIFF
--- a/gke-kafka-strimzi/terraform/gke-standard/main.tf
+++ b/gke-kafka-strimzi/terraform/gke-standard/main.tf
@@ -33,18 +33,6 @@ module "kafka_cluster" {
 
   node_pools = [
     {
-      name            = "pool-kafka"
-      disk_size_gb    = 20
-      disk_type       = "pd-standard"
-      autoscaling     = true
-      min_count       = 1
-      max_count       = 2
-      max_surge       = 1
-      max_unavailable = 0
-      machine_type    = "e2-standard-2"
-      auto_repair     = true
-    },
-    {
       name            = "pool-zookeeper"
       disk_size_gb    = 20
       disk_type       = "pd-standard"
@@ -56,6 +44,18 @@ module "kafka_cluster" {
       machine_type    = "e2-standard-2"
       auto_repair     = true
     },
+    {
+      name            = "pool-kafka"
+      disk_size_gb    = 20
+      disk_type       = "pd-ssd"
+      autoscaling     = true
+      min_count       = 1
+      max_count       = 2
+      max_surge       = 1
+      max_unavailable = 0
+      machine_type    = "e2-standard-2"
+      auto_repair     = true
+    }
   ]
   node_pools_labels = {
     all = {}

--- a/gke-kafka-strimzi/terraform/modules/cluster/main.tf
+++ b/gke-kafka-strimzi/terraform/modules/cluster/main.tf
@@ -31,6 +31,7 @@ module "kafka_cluster" {
   logging_enabled_components = ["SYSTEM_COMPONENTS","WORKLOADS"]
   monitoring_enabled_components = ["SYSTEM_COMPONENTS"]
   enable_cost_allocation = true
+  remove_default_node_pool = true
 
   cluster_resource_labels = {
     name      = "${var.cluster_prefix}-cluster"


### PR DESCRIPTION
I swapped the creation order for the zookeeper pool to avoid "Can’t scale up nodes" warning and changed disk type of kafka to ssd